### PR TITLE
Add tool name filtering to similarity recommend command

### DIFF
--- a/cli/src/mcp_tef_cli/client.py
+++ b/cli/src/mcp_tef_cli/client.py
@@ -510,11 +510,13 @@ class TefClient:
     async def get_recommendations(
         self,
         server_urls: list[str],
+        tool_names: list[str] | None = None,
     ) -> DifferentiationRecommendationResponse:
         """Get differentiation recommendations for exactly 2 tools.
 
         Args:
             server_urls: List of MCP server URLs (must yield exactly 2 tools)
+            tool_names: Optional list of tool names to filter
 
         Returns:
             DifferentiationRecommendationResponse with recommendations
@@ -526,6 +528,8 @@ class TefClient:
         payload = {
             "mcp_server_urls": server_urls,
         }
+        if tool_names:
+            payload["tool_names"] = tool_names
 
         async with self._get_client() as client:
             response = await client.post("/similarity/recommendations", json=payload)

--- a/src/mcp_tef/api/similarity.py
+++ b/src/mcp_tef/api/similarity.py
@@ -190,6 +190,7 @@ async def analyze_similarity(
     # Extract and normalize tools
     tools = await similarity_service.extract_and_normalize_tools(
         url_list=request.mcp_server_urls,
+        tool_names=request.tool_names,
     )
 
     logger.info(f"Analyzing {len(tools)} tools")
@@ -314,6 +315,7 @@ async def generate_similarity_matrix(
     # Extract and normalize tools
     tools = await similarity_service.extract_and_normalize_tools(
         url_list=request.mcp_server_urls,
+        tool_names=request.tool_names,
     )
 
     logger.info(f"Generating matrix for {len(tools)} tools")
@@ -418,6 +420,7 @@ async def get_recommendations(
     # Extract and normalize tools
     tools = await similarity_service.extract_and_normalize_tools(
         url_list=request.mcp_server_urls,
+        tool_names=request.tool_names,
     )
 
     if len(tools) != 2:

--- a/src/mcp_tef/models/schemas.py
+++ b/src/mcp_tef/models/schemas.py
@@ -393,6 +393,14 @@ class SimilarityAnalysisRequest(BaseModel):
     mcp_server_urls: list[str] = Field(
         min_length=1, description="Array of MCP server URLs to fetch tools from"
     )
+    tool_names: list[str] | None = Field(
+        None,
+        description=(
+            "Optional list of tool names to filter. If provided, only tools with matching names "
+            "will be included in the analysis. Useful when a server exposes many tools but you "
+            "want to compare specific ones."
+        ),
+    )
 
     # Configuration
     embedding_model: str | None = Field(


### PR DESCRIPTION
## Problem

The `similarity recommend` command requires exactly 2 tools, but when a server exposes many tools (e.g., 49 tools), users had no way to select specific tools for comparison.

## Solution

Added tool name filtering support:

1. **API**: Added optional `tool_names` field to `SimilarityAnalysisRequest` schema
2. **Service**: Updated `extract_and_normalize_tools()` to filter tools by name when provided
3. **CLI**: Added `--tool-names` option to the `recommend` command

## Usage

Users can now filter specific tools from a server with many tools:

```bash
mtef similarity recommend \
  --insecure \
  --server-urls http://host.docker.internal:8080/github/mcp \
  --tool-names search_issues,search_pull_requests
```

This will:
1. Connect to the MCP server
2. Filter to only the specified tool names
3. Generate recommendations for exactly those 2 tools

## Changes

- Added `tool_names: list[str] | None` field to `SimilarityAnalysisRequest`
- Updated `SimilarityService.extract_and_normalize_tools()` to accept and filter by tool names
- Updated all similarity API endpoints to pass `tool_names` parameter
- Added `--tool-names` CLI option with comma-separated tool names
- Improved error messages when filtered tools are not found

## Testing

- All quality gates passed (format, lint, typecheck)
- All existing tests pass
- Manual testing confirmed the feature works as expected