### PR TITLE
docs: update examples to use streamable-http and frontier models

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ uv run python -m mcp_tef
 - **Custom certs**: `--tls-cert-file` and `--tls-key-file` flags
 - **Development**: `--tls-enabled=false` for HTTP (⚠️ not for production)
 
+**Transport Support:**
+- **Supported**: SSE and streamable-http transports only
+- **stdio servers**: mcp-tef does not support stdio servers directly, but you can use stdio-based MCP servers through [ToolHive](https://docs.stacklok.com/toolhive/guides-mcp/run-mcp-servers), which runs stdio servers and exposes them via SSE or streamable-http endpoints that mcp-tef can connect to
+
 See [docs/testing-with-ollama.md](docs/testing-with-ollama.md) and [docs/tls-configuration.md](docs/tls-configuration.md) for details.
 
 ## Core Workflows


### PR DESCRIPTION
## Summary

Updates documentation examples to match the blog post and ensure all examples work correctly:

- ✅ Update all examples to use `streamable-http` transport (not deprecated SSE)
- ✅ Change placeholder URLs to working `localhost:8080` examples
- ✅ Make OpenRouter/Claude primary examples (recommended for production)
- ✅ Keep Ollama as alternative for local testing
- ✅ Update test case example from weather to GitHub repository search
- ✅ Add transport support section to README
- ✅ Update troubleshooting section with correct URL formats

## Changes

### `docs/quickstart.md`
- Updated test case creation example to use GitHub repository search
- Changed all server URLs from placeholder `my-mcp-server.com/sse` to working `localhost:8080/github/mcp:streamable-http`
- Made OpenRouter with Claude the primary example with notes about production testing
- Updated similarity detection and tool quality examples to use working URLs
- Fixed troubleshooting section to show correct URL formats

### `README.md`
- Added transport support section clarifying SSE and streamable-http support

All examples now use the correct transport format and working server URLs that match the blog post.