### PR TITLE
Add support for multiple tool calls in test cases

### DIFF
--- a/cli/src/mcp_tef_cli/client.py
+++ b/cli/src/mcp_tef_cli/client.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 import httpx
 from mcp_tef_models.schemas import (
     DifferentiationRecommendationResponse,
+    ExpectedToolCall,
     MCPServerConfig,
     ModelSettingsCreate,
     OverlapMatrixResponse,
@@ -178,9 +179,8 @@ class TefClient:
         name: str,
         query: str,
         available_mcp_servers: list[MCPServerConfig],
-        expected_mcp_server_url: str | None = None,
-        expected_tool_name: str | None = None,
-        expected_parameters: dict | None = None,
+        expected_tool_calls: list[ExpectedToolCall] | None = None,
+        order_dependent_matching: bool = False,
     ) -> TestCaseResponse:
         """Create a new test case.
 
@@ -188,9 +188,8 @@ class TefClient:
             name: Descriptive name for the test case
             query: User query to evaluate
             available_mcp_servers: List of MCPServerConfig objects
-            expected_mcp_server_url: Expected MCP server URL (null for negative tests)
-            expected_tool_name: Expected tool name (null for negative tests)
-            expected_parameters: Expected parameters as dict
+            expected_tool_calls: List of expected tool calls (null/empty for negative tests)
+            order_dependent_matching: Whether tool calls must match in exact order
 
         Returns:
             TestCaseResponse with created test case
@@ -202,9 +201,8 @@ class TefClient:
             name=name,
             query=query,
             available_mcp_servers=available_mcp_servers,
-            expected_mcp_server_url=expected_mcp_server_url,
-            expected_tool_name=expected_tool_name,
-            expected_parameters=expected_parameters,
+            expected_tool_calls=expected_tool_calls,
+            order_dependent_matching=order_dependent_matching,
         )
 
         async with self._get_client() as client:

--- a/cli/tests/scripts/test_cases.json
+++ b/cli/tests/scripts/test_cases.json
@@ -3,7 +3,31 @@
     "name": "E2E Fetch Test - Positive",
     "query": "Fetch the content from https://example.com",
     "available_mcp_servers": ["${MCP_SERVER_URL}"],
-    "expected_mcp_server_url": "${MCP_SERVER_URL}",
-    "expected_tool_name": "fetch"
+    "expected_tool_calls": [
+      {
+        "mcp_server_url": "${MCP_SERVER_URL}",
+        "tool_name": "fetch",
+        "parameters": null
+      }
+    ],
+    "order_dependent_matching": false
+  },
+  {
+    "name": "Multi-Tool Example",
+    "query": "Fetch data and then analyze it",
+    "available_mcp_servers": ["${MCP_SERVER_URL}"],
+    "expected_tool_calls": [
+      {
+        "mcp_server_url": "${MCP_SERVER_URL}",
+        "tool_name": "fetch",
+        "parameters": {"url": "https://example.com"}
+      },
+      {
+        "mcp_server_url": "${MCP_SERVER_URL}",
+        "tool_name": "analyze",
+        "parameters": null
+      }
+    ],
+    "order_dependent_matching": true
   }
 ]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -743,12 +743,34 @@ components:
           format: date-time
 
     # ==========================================================================
-    # TEST CASES (001 base, 003: removed model_id)
+    # TEST CASES (001 base, 003: removed model_id, multiple-tool-evals: multi-tool support)
     # ==========================================================================
-    
+
+    ExpectedToolCall:
+      type: object
+      required: [mcp_server_url, tool_name]
+      properties:
+        mcp_server_url:
+          type: string
+          minLength: 1
+          description: MCP server URL that provides this tool
+        tool_name:
+          type: string
+          minLength: 1
+          description: Tool name to be selected
+        parameters:
+          type: object
+          nullable: true
+          description: Expected parameter values (null = don't validate parameters)
+      example:
+        mcp_server_url: "http://localhost:3000"
+        tool_name: "get_weather"
+        parameters:
+          location: "San Francisco"
+
     TestCaseCreate:
       type: object
-      required: [name, query, expected_mcp_server_name, expected_tool_name]
+      required: [name, query, available_mcp_servers]
       properties:
         name:
           type: string
@@ -756,19 +778,28 @@ components:
         query:
           type: string
           minLength: 1
-        expected_mcp_server_name:
-          type: string
-          minLength: 1
-        expected_tool_name:
-          type: string
-          minLength: 1
-        expected_parameters:
-          type: object
+        expected_tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExpectedToolCall'
           nullable: true
+          maxItems: 100
+          description: List of expected tool calls (null or empty = expect no tools)
+        order_dependent_matching:
+          type: boolean
+          default: false
+          description: If true, tool calls must match in exact order. If false (default), order-independent matching is used.
+        available_mcp_servers:
+          type: array
+          items:
+            type: string
+            minLength: 1
+          minItems: 1
+          description: List of MCP server URLs to fetch tools from at test execution time
 
     TestCaseResponse:
       type: object
-      required: [id, name, query, expected_mcp_server_name, expected_tool_name, created_at, updated_at]
+      required: [id, name, query, order_dependent_matching, available_mcp_servers, created_at, updated_at]
       properties:
         id:
           type: string
@@ -777,13 +808,17 @@ components:
           type: string
         query:
           type: string
-        expected_mcp_server_name:
-          type: string
-        expected_tool_name:
-          type: string
-        expected_parameters:
-          type: object
+        expected_tool_calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExpectedToolCall'
           nullable: true
+        order_dependent_matching:
+          type: boolean
+        available_mcp_servers:
+          type: array
+          items:
+            type: string
         created_at:
           type: string
           format: date-time
@@ -875,16 +910,28 @@ components:
         status:
           type: string
           enum: [pending, running, completed, failed]
-        confidence_score:
+        llm_confidence:
+          type: string
+          enum: [high, low]
+          nullable: true
+          description: 'multiple-tool-evals: LLM-reported confidence level'
+        avg_parameter_correctness:
           type: number
           format: float
           nullable: true
           minimum: 0.0
-          maximum: 1.0
+          maximum: 10.0
+          description: 'multiple-tool-evals: Average parameter correctness score (0-10) across all TP matches'
+        confidence_score:
+          type: string
+          enum: ['robust description', 'needs clarity', 'misleading description']
+          nullable: true
+          description: 'Confidence category based on description quality'
         classification:
           type: string
           enum: [TP, FP, TN, FN]
           nullable: true
+          description: 'multiple-tool-evals: Overall classification, aggregated from tool_call_matches'
         execution_time_ms:
           type: integer
           nullable: true

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart Guide: MCP Tool Evaluation System
 
-**Last Updated**: 2025-11-10
+**Last Updated**: 2025-12-16
 
 This guide shows you how to use mcp-tef to evaluate and improve your MCP tools. Follow the workflows below based on your use case.
 
@@ -102,8 +102,9 @@ Expected response:
 ### 1. Test Case
 A test scenario that defines:
 - **Query**: User's natural language request
-- **Expected Tool**: Which tool should be selected
-- **Expected Parameters**: What parameters should be extracted
+- **Expected Tool Calls**: Which tool(s) should be selected (supports 0-N tools)
+- **Expected Parameters**: What parameters should be extracted for each tool
+- **Order Dependent Matching**: Whether tool call sequence matters (default: false)
 - **Available Servers**: List of MCP server URLs to fetch tools from
 
 ### 2. Test Run
@@ -145,11 +146,16 @@ curl -k -X POST https://localhost:8000/test-cases \
   -d '{
     "name": "Weather query test",
     "query": "What is the weather in San Francisco?",
-    "expected_mcp_server_url": "https://my-mcp-server.com/sse",
-    "expected_tool_name": "get_weather",
-    "expected_parameters": {
-      "location": "San Francisco"
-    },
+    "expected_tool_calls": [
+      {
+        "mcp_server_url": "https://my-mcp-server.com/sse",
+        "tool_name": "get_weather",
+        "parameters": {
+          "location": "San Francisco"
+        }
+      }
+    ],
+    "order_dependent_matching": false,
     "available_mcp_servers": [
       "https://my-mcp-server.com/sse",
       "https://another-server.com/sse"
@@ -180,9 +186,14 @@ mtef test-case create \
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "name": "Weather query test",
   "query": "What is the weather in San Francisco?",
-  "expected_mcp_server_url": "https://my-mcp-server.com/sse",
-  "expected_tool_name": "get_weather",
-  "expected_parameters": {"location": "San Francisco"},
+  "expected_tool_calls": [
+    {
+      "mcp_server_url": "https://my-mcp-server.com/sse",
+      "tool_name": "get_weather",
+      "parameters": {"location": "San Francisco"}
+    }
+  ],
+  "order_dependent_matching": false,
   "available_mcp_servers": [
     "https://my-mcp-server.com/sse",
     "https://another-server.com/sse"
@@ -194,8 +205,10 @@ mtef test-case create \
 
 **💡 Key Points**:
 - `available_mcp_servers`: Tools will be fetched from these URLs at test execution time
-- `expected_mcp_server_url` + `expected_tool_name`: What you expect the LLM to select
-- `expected_parameters`: What parameters you expect to be extracted
+- `expected_tool_calls`: List of tool(s) you expect the LLM to select (supports multiple tools)
+- `order_dependent_matching`: Set to `true` if tool call sequence matters (default: `false` for order-independent matching)
+- Each expected tool call specifies: `mcp_server_url`, `tool_name`, and optional `parameters`
+- Empty `expected_tool_calls` array = expect no tools to be selected (True Negative test)
 
 ### Step 2: Run the Test
 

--- a/src/mcp_tef/services/llm_service.py
+++ b/src/mcp_tef/services/llm_service.py
@@ -151,7 +151,7 @@ class LLMService:
         """
         current_tool_call = None
         current_tool_name = None
-        tool_calls = []
+        tool_calls: list[LLMToolCall] = []
         raw_response = ""
 
         for message in result.all_messages():
@@ -222,7 +222,13 @@ class LLMService:
                             "UNIDENTIFIED PART", type(part).__name__, timestamp
                         )
 
-        return tool_calls, raw_response
+        # Remove any 'final_result' tool calls from the returned list. This is the tool call
+        # that Pydantic AI uses to return the final structured output
+        final_tool_calls = [
+            tool_call for tool_call in tool_calls if tool_call.name != "final_result"
+        ]
+
+        return final_tool_calls, raw_response
 
     async def select_tool(self, query: str) -> LLMResponse:
         """Ask LLM to select a tool for the given query.

--- a/src/mcp_tef/services/tool_call_matcher.py
+++ b/src/mcp_tef/services/tool_call_matcher.py
@@ -1,0 +1,356 @@
+"""Service for matching expected tool calls against actual LLM tool calls."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from mcp_tef_models.schemas import ExpectedToolCall
+
+from mcp_tef.models.llm_models import LLMToolCall
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class ToolCallMatchResult:
+    """Result of matching one expected call against one actual call."""
+
+    expected_index: int | None  # None for FP
+    actual_index: int | None  # None for FN
+    match_type: str  # "TP", "FP", "FN", "TN"
+    parameter_correctness: float | None
+    expected_call: ExpectedToolCall | None
+    actual_call: LLMToolCall | None
+    parameter_justification: str | None  # Explanation of score
+
+
+class ToolCallMatcher:
+    """Matches expected tool calls against actual LLM responses."""
+
+    def match_order_independent(
+        self,
+        expected_calls: list[ExpectedToolCall],
+        actual_calls: list[LLMToolCall],
+    ) -> list[ToolCallMatchResult]:
+        """Match expected vs actual tool calls in order-independent manner.
+
+        Algorithm (Greedy Best-Fit):
+        1. For each expected call, find best matching actual call (by tool name + server)
+        2. Mark matched pairs as TP, calculate parameter scores
+        3. Remaining expected calls = FN
+        4. Remaining actual calls = FP
+        5. If no expected calls and no actual calls = TN
+
+        Args:
+            expected_calls: List of expected tool calls
+            actual_calls: List of actual LLM tool calls
+
+        Returns:
+            List of match results (one per expected or actual tool call)
+        """
+        results = []
+        used_actual_indices = set()
+
+        # Handle TN case (no tools expected, no tools selected)
+        if not expected_calls and not actual_calls:
+            return [
+                ToolCallMatchResult(
+                    expected_index=None,
+                    actual_index=None,
+                    match_type="TN",
+                    parameter_correctness=None,
+                    expected_call=None,
+                    actual_call=None,
+                    parameter_justification=None,
+                )
+            ]
+
+        # Match expected calls to actual calls
+        for exp_idx, expected in enumerate(expected_calls):
+            best_match_idx = None
+
+            # Find matching actual call by tool name and server
+            for act_idx, actual in enumerate(actual_calls):
+                if act_idx in used_actual_indices:
+                    continue
+
+                # Check if tool names match and server matches. We don't have the server_name
+                # coming from the LLM in all cases, so we only match by name here.
+                if actual.name == expected.tool_name:
+                    # Found a match
+                    best_match_idx = act_idx
+                    break
+
+            if best_match_idx is not None:
+                # TP: Found matching tool call
+                actual = actual_calls[best_match_idx]
+                used_actual_indices.add(best_match_idx)
+
+                param_score, param_justification = self._evaluate_parameters(
+                    expected.parameters, actual.parameters
+                )
+
+                results.append(
+                    ToolCallMatchResult(
+                        expected_index=exp_idx,
+                        actual_index=best_match_idx,
+                        match_type="TP",
+                        parameter_correctness=param_score,
+                        expected_call=expected,
+                        actual_call=actual,
+                        parameter_justification=param_justification,
+                    )
+                )
+            else:
+                # FN: Expected tool call not found in actual
+                results.append(
+                    ToolCallMatchResult(
+                        expected_index=exp_idx,
+                        actual_index=None,
+                        match_type="FN",
+                        parameter_correctness=0.0,
+                        expected_call=expected,
+                        actual_call=None,
+                        parameter_justification="Expected tool not called by LLM",
+                    )
+                )
+
+        # FP: Actual tool calls that weren't matched
+        for act_idx, actual in enumerate(actual_calls):
+            if act_idx not in used_actual_indices:
+                results.append(
+                    ToolCallMatchResult(
+                        expected_index=None,
+                        actual_index=act_idx,
+                        match_type="FP",
+                        parameter_correctness=None,
+                        expected_call=None,
+                        actual_call=actual,
+                        parameter_justification=None,
+                    )
+                )
+
+        return results
+
+    def match_order_dependent(
+        self,
+        expected_calls: list[ExpectedToolCall],
+        actual_calls: list[LLMToolCall],
+    ) -> list[ToolCallMatchResult]:
+        """Match expected vs actual tool calls in order-dependent manner.
+
+        Algorithm (Positional Matching):
+        1. Compare position-by-position (0th expected vs 0th actual, etc.)
+        2. If tool names match = TP
+        3. If tool names differ = FN for expected + FP for actual
+        4. Extra actual calls = FP
+        5. Missing actual calls = FN
+
+        Args:
+            expected_calls: List of expected tool calls
+            actual_calls: List of actual LLM tool calls
+
+        Returns:
+            List of match results
+        """
+        results = []
+        max_len = max(len(expected_calls), len(actual_calls))
+
+        # Handle TN case
+        if max_len == 0:
+            return [
+                ToolCallMatchResult(
+                    expected_index=None,
+                    actual_index=None,
+                    match_type="TN",
+                    parameter_correctness=None,
+                    expected_call=None,
+                    actual_call=None,
+                    parameter_justification=None,
+                )
+            ]
+
+        for i in range(max_len):
+            expected = expected_calls[i] if i < len(expected_calls) else None
+            actual = actual_calls[i] if i < len(actual_calls) else None
+
+            if expected and actual:
+                # Both exist at this position
+                if expected.tool_name == actual.name:
+                    # TP: Correct tool in correct position
+                    param_score, param_justification = self._evaluate_parameters(
+                        expected.parameters, actual.parameters
+                    )
+                    results.append(
+                        ToolCallMatchResult(
+                            expected_index=i,
+                            actual_index=i,
+                            match_type="TP",
+                            parameter_correctness=param_score,
+                            expected_call=expected,
+                            actual_call=actual,
+                            parameter_justification=param_justification,
+                        )
+                    )
+                else:
+                    # Mismatch: FN for expected + FP for actual
+                    results.append(
+                        ToolCallMatchResult(
+                            expected_index=i,
+                            actual_index=None,
+                            match_type="FN",
+                            parameter_correctness=0.0,
+                            expected_call=expected,
+                            actual_call=None,
+                            parameter_justification=f"Expected tool not called at position {i}",
+                        )
+                    )
+                    results.append(
+                        ToolCallMatchResult(
+                            expected_index=None,
+                            actual_index=i,
+                            match_type="FP",
+                            parameter_correctness=None,
+                            expected_call=None,
+                            actual_call=actual,
+                            parameter_justification=None,
+                        )
+                    )
+            elif expected:
+                # FN: Expected but no actual at this position
+                results.append(
+                    ToolCallMatchResult(
+                        expected_index=i,
+                        actual_index=None,
+                        match_type="FN",
+                        parameter_correctness=0.0,
+                        expected_call=expected,
+                        actual_call=None,
+                        parameter_justification=f"Expected tool not called at position {i}",
+                    )
+                )
+            else:
+                # FP: Actual but no expected at this position
+                results.append(
+                    ToolCallMatchResult(
+                        expected_index=None,
+                        actual_index=i,
+                        match_type="FP",
+                        parameter_correctness=None,
+                        expected_call=None,
+                        actual_call=actual,
+                        parameter_justification=None,
+                    )
+                )
+
+        return results
+
+    def _evaluate_parameters(
+        self,
+        expected_params: dict[str, Any] | None,
+        actual_params: dict[str, Any] | None,
+    ) -> tuple[float, str]:
+        """Evaluate parameter correctness (0-10 scale) with justification.
+
+        - Completeness (2.5 pts): All required params present
+        - Correctness (2.5 pts): Values match expected
+        - Type conformance (2.5 pts): Types match
+        - No hallucinations (2.5 pts): No extra params
+
+        Args:
+            expected_params: Expected parameter values
+            actual_params: Actual parameter values from LLM
+
+        Returns:
+            Tuple of (score, justification)
+        """
+        if expected_params is None or not expected_params:
+            return 10.0, "No parameters expected, full score"
+
+        if actual_params is None or not actual_params:
+            return 0.0, "No parameters provided by LLM"
+
+        total_expected = len(expected_params)
+        completeness_params = 0
+        correctness_params = 0
+        conformance_params = 0
+
+        for param_name, expected_value in expected_params.items():
+            if param_name in actual_params:
+                completeness_params += 1
+                actual_value = actual_params[param_name]
+
+                if self._normalize_value(actual_value) == self._normalize_value(expected_value):
+                    correctness_params += 1
+
+                # Check type conformance with numeric equivalence support
+                if self._types_match(actual_value, expected_value):
+                    conformance_params += 1
+
+        total_score = 0.0
+        total_score += 2.5 * (completeness_params / total_expected)
+        total_score += 2.5 * (correctness_params / total_expected)
+        total_score += 2.5 * (conformance_params / total_expected)
+
+        extra_params = set(actual_params.keys()) - set(expected_params.keys())
+        if not extra_params:
+            total_score += 2.5
+
+        # Generate justification
+        justification_parts = []
+        if completeness_params < total_expected:
+            missing = set(expected_params.keys()) - set(actual_params.keys())
+            justification_parts.append(f"Missing params: {missing}")
+        if correctness_params < total_expected:
+            justification_parts.append(
+                f"Incorrect values: {total_expected - correctness_params}/{total_expected}"
+            )
+        if conformance_params < total_expected:
+            justification_parts.append(
+                f"Type mismatches: {total_expected - conformance_params}/{total_expected}"
+            )
+        if extra_params:
+            justification_parts.append(f"Extra params: {extra_params}")
+
+        if not justification_parts:
+            justification = "Perfect parameter match"
+        else:
+            justification = "; ".join(justification_parts)
+
+        return total_score, justification
+
+    def _types_match(self, actual_value: Any, expected_value: Any) -> bool:
+        """Check if two values have matching types, with numeric equivalence support.
+
+        Args:
+            actual_value: The actual parameter value
+            expected_value: The expected parameter value
+
+        Returns:
+            True if types match or both are numeric types
+        """
+        # Handle exact type match
+        if type(actual_value) is type(expected_value):
+            return True
+
+        # Handle numeric equivalence (int/float are considered compatible)
+        return isinstance(actual_value, (int, float)) and isinstance(expected_value, (int, float))
+
+    def _normalize_value(self, value: Any) -> str:
+        """Normalize value for comparison.
+
+        Args:
+            value: Value to normalize
+
+        Returns:
+            Normalized string representation
+        """
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return str(value).lower()
+        if isinstance(value, (int, float)):
+            return str(value)
+        if isinstance(value, str):
+            return value.strip().lower()
+        return str(value).strip().lower()

--- a/src/mcp_tef/storage/schema.sql
+++ b/src/mcp_tef/storage/schema.sql
@@ -41,22 +41,15 @@ CREATE TABLE IF NOT EXISTS tool_definitions (
 CREATE INDEX IF NOT EXISTS idx_tool_name ON tool_definitions(name);
 CREATE INDEX IF NOT EXISTS idx_tool_test_run ON tool_definitions(test_run_id);
 
--- Test Cases (MODIFIED - removed model_id FK, made expected_tool nullable, uses URL not name)
+-- Test Cases (MODIFIED - uses expected_tool_calls table for multi-tool support)
 CREATE TABLE IF NOT EXISTS test_cases (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     query TEXT NOT NULL,
-    expected_mcp_server_url TEXT,  -- Can be NULL if no tool expected
-    expected_tool_name TEXT,  -- Can be NULL if no tool expected
-    expected_parameters TEXT,  -- JSON as TEXT, can be NULL
+    order_dependent_matching BOOLEAN NOT NULL DEFAULT 0,  -- 0 = order-independent, 1 = order-dependent
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CHECK ((expected_mcp_server_url IS NULL AND expected_tool_name IS NULL AND expected_parameters IS NULL) OR
-           (expected_mcp_server_url IS NOT NULL AND expected_tool_name IS NOT NULL))
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-
-CREATE INDEX IF NOT EXISTS idx_test_case_expected_server ON test_cases(expected_mcp_server_url);
-CREATE INDEX IF NOT EXISTS idx_test_case_expected_tool ON test_cases(expected_tool_name);
 
 -- Junction table for test case available MCP servers (many-to-many)
 CREATE TABLE IF NOT EXISTS test_case_mcp_servers (
@@ -70,17 +63,31 @@ CREATE TABLE IF NOT EXISTS test_case_mcp_servers (
 
 CREATE INDEX IF NOT EXISTS idx_test_case_mcp_servers_test_case ON test_case_mcp_servers(test_case_id);
 
--- Test Runs (MODIFIED - added model_settings_id FK, llm_confidence, parameter_correctness)
+-- Expected Tool Calls (NEW - normalized storage for multiple expected tools per test case)
+CREATE TABLE IF NOT EXISTS expected_tool_calls (
+    id TEXT PRIMARY KEY,
+    test_case_id TEXT NOT NULL,
+    mcp_server_url TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    parameters TEXT,  -- JSON as TEXT, can be NULL
+    sequence_order INTEGER NOT NULL,  -- 0-indexed order for order-dependent matching
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (test_case_id) REFERENCES test_cases(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_expected_tool_calls_test_case ON expected_tool_calls(test_case_id);
+CREATE INDEX IF NOT EXISTS idx_expected_tool_calls_server ON expected_tool_calls(mcp_server_url);
+CREATE INDEX IF NOT EXISTS idx_expected_tool_calls_tool ON expected_tool_calls(tool_name);
+
+-- Test Runs (MODIFIED - removed single-tool fields: selected_tool_id, extracted_parameters, parameter_correctness)
 CREATE TABLE IF NOT EXISTS test_runs (
     id TEXT PRIMARY KEY,
     test_case_id TEXT NOT NULL,
-    model_settings_id TEXT,  -- NEW: Link to model configuration used
+    model_settings_id TEXT,  -- Link to model configuration used
     status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'completed', 'failed')),
     llm_response_raw TEXT,  -- JSON as TEXT
-    selected_tool_id TEXT,
-    extracted_parameters TEXT,  -- JSON as TEXT
     llm_confidence TEXT CHECK (llm_confidence IS NULL OR llm_confidence IN ('high', 'low')),
-    parameter_correctness REAL CHECK (parameter_correctness IS NULL OR (parameter_correctness >= 0 AND parameter_correctness <= 10)),
+    avg_parameter_correctness REAL CHECK (avg_parameter_correctness IS NULL OR (avg_parameter_correctness >= 0 AND avg_parameter_correctness <= 10)),  -- Average parameter correctness across all tool call matches
     confidence_score TEXT CHECK (confidence_score IS NULL OR confidence_score IN ('robust description', 'needs clarity', 'misleading description')),
     classification TEXT CHECK (classification IS NULL OR classification IN ('TP', 'FP', 'TN', 'FN')),
     execution_time_ms INTEGER CHECK (execution_time_ms IS NULL OR execution_time_ms > 0),
@@ -88,14 +95,32 @@ CREATE TABLE IF NOT EXISTS test_runs (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     completed_at TIMESTAMP,
     FOREIGN KEY (test_case_id) REFERENCES test_cases(id) ON DELETE CASCADE,
-    FOREIGN KEY (model_settings_id) REFERENCES model_settings(id) ON DELETE SET NULL,
-    FOREIGN KEY (selected_tool_id) REFERENCES tool_definitions(id) ON DELETE SET NULL
+    FOREIGN KEY (model_settings_id) REFERENCES model_settings(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_test_run_test_case ON test_runs(test_case_id);
 CREATE INDEX IF NOT EXISTS idx_test_run_model_settings ON test_runs(model_settings_id);
 CREATE INDEX IF NOT EXISTS idx_test_run_status ON test_runs(status);
 CREATE INDEX IF NOT EXISTS idx_test_run_created_at ON test_runs(created_at);
+
+-- Tool Call Matches (NEW - per-tool-call evaluation results)
+CREATE TABLE IF NOT EXISTS tool_call_matches (
+    id TEXT PRIMARY KEY,
+    test_run_id TEXT NOT NULL,
+    expected_tool_call_id TEXT,  -- NULL for FP cases
+    actual_tool_id TEXT,  -- NULL for FN/TN cases (FK to tool_definitions)
+    match_type TEXT NOT NULL CHECK (match_type IN ('TP', 'FP', 'FN', 'TN')),
+    parameter_correctness REAL CHECK (parameter_correctness IS NULL OR (parameter_correctness >= 0 AND parameter_correctness <= 10)),
+    actual_parameters TEXT,  -- JSON as TEXT, NULL for FN/TN cases
+    parameter_justification TEXT,  -- Explanation of parameter_correctness score
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (test_run_id) REFERENCES test_runs(id) ON DELETE CASCADE,
+    FOREIGN KEY (expected_tool_call_id) REFERENCES expected_tool_calls(id) ON DELETE SET NULL,
+    FOREIGN KEY (actual_tool_id) REFERENCES tool_definitions(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_call_matches_test_run ON tool_call_matches(test_run_id);
+CREATE INDEX IF NOT EXISTS idx_tool_call_matches_type ON tool_call_matches(match_type);
 
 -- Triggers to update updated_at timestamp
 

--- a/src/mcp_tef/storage/tool_call_match_repository.py
+++ b/src/mcp_tef/storage/tool_call_match_repository.py
@@ -1,0 +1,125 @@
+"""Repository for tool call match database operations."""
+
+import json
+from typing import Any
+from uuid import uuid4
+
+import aiosqlite
+import structlog
+
+from mcp_tef.api.errors import DatabaseError
+
+logger = structlog.get_logger(__name__)
+
+
+class ToolCallMatchRepository:
+    """Repository for managing tool call matches in SQLite."""
+
+    def __init__(self, db: aiosqlite.Connection):
+        """Initialize repository with database connection.
+
+        Args:
+            db: Active aiosqlite connection
+        """
+        self.db = db
+
+    async def create(
+        self,
+        test_run_id: str,
+        expected_tool_call_id: str | None,
+        actual_tool_id: str | None,
+        match_type: str,
+        parameter_correctness: float | None,
+        actual_parameters: dict[str, Any] | None = None,
+        parameter_justification: str | None = None,
+    ) -> str:
+        """Create a new tool call match record.
+
+        Args:
+            test_run_id: Test run ID
+            expected_tool_call_id: Expected tool call ID (None for FP)
+            actual_tool_id: Actual tool ID (None for FN/TN)
+            match_type: Match classification (TP/FP/FN/TN)
+            parameter_correctness: Parameter correctness score (0-10)
+            actual_parameters: Actual parameters from LLM (None for FN/TN)
+            parameter_justification: Explanation of parameter score
+
+        Returns:
+            Created match ID
+
+        Raises:
+            DatabaseError: If database operation fails
+        """
+        match_id = str(uuid4())
+
+        # Serialize actual_parameters to JSON if present
+        actual_params_json = json.dumps(actual_parameters) if actual_parameters else None
+
+        try:
+            await self.db.execute(
+                """
+                INSERT INTO tool_call_matches
+                (id, test_run_id, expected_tool_call_id, actual_tool_id,
+                 match_type, parameter_correctness,
+                 actual_parameters, parameter_justification)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    match_id,
+                    test_run_id,
+                    expected_tool_call_id,
+                    actual_tool_id,
+                    match_type,
+                    parameter_correctness,
+                    actual_params_json,
+                    parameter_justification,
+                ),
+            )
+            await self.db.commit()
+            logger.debug(
+                "Created tool call match",
+                match_id=match_id,
+                test_run_id=test_run_id,
+                match_type=match_type,
+            )
+            return match_id
+        except Exception as e:
+            logger.error(
+                "Failed to create tool call match",
+                test_run_id=test_run_id,
+                match_type=match_type,
+                error=str(e),
+            )
+            raise DatabaseError(f"Failed to create tool call match: {str(e)}", e) from e
+
+    async def get_expected_call_id(self, test_case_id: str, sequence_order: int) -> str | None:
+        """Get the ID of an expected tool call by its sequence order.
+
+        Args:
+            test_case_id: Test case ID
+            sequence_order: Sequence order of the expected tool call
+
+        Returns:
+            Expected tool call ID or None if not found
+
+        Raises:
+            DatabaseError: If database operation fails
+        """
+        try:
+            cursor = await self.db.execute(
+                """
+                SELECT id FROM expected_tool_calls
+                WHERE test_case_id = ? AND sequence_order = ?
+                """,
+                (test_case_id, sequence_order),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else None
+        except Exception as e:
+            logger.warning(
+                "Failed to get expected call ID",
+                test_case_id=test_case_id,
+                sequence_order=sequence_order,
+                error=str(e),
+            )
+            raise DatabaseError(f"Failed to get expected call ID: {str(e)}", e) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,8 +298,13 @@ async def test_run_id(client):
             json={
                 "name": "Fixture test case",
                 "query": "Test query for fixture",
-                "expected_mcp_server_url": "http://localhost:9999",
-                "expected_tool_name": "fixture_tool",
+                "expected_tool_calls": [
+                    {
+                        "mcp_server_url": "http://localhost:9999",
+                        "tool_name": "fixture_tool",
+                        "parameters": None,
+                    }
+                ],
                 "available_mcp_servers": [
                     {"url": "http://localhost:9999", "transport": "streamable-http"}
                 ],

--- a/tests/contract/test_metrics_api.py
+++ b/tests/contract/test_metrics_api.py
@@ -120,7 +120,6 @@ async def test_runs_with_known_data(test_db):
         )
 
         # Create tool definition for selected tool (if any)
-        selected_tool_id = None
         if outcome["selected_tool"]:
             from mcp_tef.models.schemas import ToolDefinitionCreate
 
@@ -131,18 +130,15 @@ async def test_runs_with_known_data(test_db):
                 mcp_server_url=server_url,
                 test_run_id=test_run.id,
             )
-            created_tool = await tool_repo.create(tool_def)
-            selected_tool_id = created_tool.id
+            await tool_repo.create(tool_def)
 
         # Update test run with results
         await test_run_repo.update_status(
             test_run_id=test_run.id,
             status="completed",
-            selected_tool_id=selected_tool_id,
-            extracted_parameters=outcome["selected_params"],
             confidence_score=outcome["confidence_score"],
             classification=outcome["classification"],
-            parameter_correctness=outcome["parameter_correctness"],
+            avg_parameter_correctness=outcome["parameter_correctness"],
             execution_time_ms=outcome["execution_time_ms"],
         )
 
@@ -246,14 +242,12 @@ async def test_runs_for_filtering(test_db):
         mcp_server_url=server_url_1,
         test_run_id=test_run_1.id,
     )
-    created_tool_1 = await tool_repo.create(tool_1)
+    await tool_repo.create(tool_1)
 
     # Update test_run_1 with results
     await test_run_repo.update_status(
         test_run_id=test_run_1.id,
         status="completed",
-        selected_tool_id=created_tool_1.id,
-        extracted_parameters={"param": "value"},
         confidence_score="robust description",
         execution_time_ms=100,
     )
@@ -271,14 +265,12 @@ async def test_runs_for_filtering(test_db):
         mcp_server_url=server_url_2,
         test_run_id=test_run_2.id,
     )
-    created_tool_2 = await tool_repo.create(tool_2)
+    await tool_repo.create(tool_2)
 
     # Update test_run_2 with results
     await test_run_repo.update_status(
         test_run_id=test_run_2.id,
         status="completed",
-        selected_tool_id=created_tool_2.id,
-        extracted_parameters={"param": "value"},
         confidence_score="robust description",
         execution_time_ms=100,
     )

--- a/tests/contract/test_test_cases_api.py
+++ b/tests/contract/test_test_cases_api.py
@@ -36,9 +36,13 @@ async def test_create_test_case(client: AsyncClient, mcp_server_url: str):
         payload = {
             "name": "Test weather query",
             "query": "What is the weather in San Francisco?",
-            "expected_mcp_server_url": mcp_server_url,
-            "expected_tool_name": "test_tool",
-            "expected_parameters": {"location": "San Francisco"},
+            "expected_tool_calls": [
+                {
+                    "mcp_server_url": mcp_server_url,
+                    "tool_name": "test_tool",
+                    "parameters": {"location": "San Francisco"},
+                }
+            ],
             "available_mcp_servers": [{"url": mcp_server_url, "transport": "streamable-http"}],
         }
 
@@ -49,9 +53,10 @@ async def test_create_test_case(client: AsyncClient, mcp_server_url: str):
         assert "id" in data
         assert data["name"] == payload["name"]
         assert data["query"] == payload["query"]
-        assert data["expected_mcp_server_url"] == mcp_server_url
-        assert data["expected_tool_name"] == "test_tool"
-        assert data["expected_parameters"] == payload["expected_parameters"]
+        assert len(data["expected_tool_calls"]) == 1
+        assert data["expected_tool_calls"][0]["mcp_server_url"] == mcp_server_url
+        assert data["expected_tool_calls"][0]["tool_name"] == "test_tool"
+        assert data["expected_tool_calls"][0]["parameters"] == {"location": "San Francisco"}
         assert data["available_mcp_servers"] == [
             {"url": mcp_server_url, "transport": "streamable-http"}
         ]


### PR DESCRIPTION
Closes: #26 

Changes:
- Test cases now support multiple expected tool calls instead of single tool/server pairs
- Added order-dependent and order-independent matching modes
- New tool_call_matcher service handles matching logic between expected and actual calls
- Database schema updated with tool_call_matches table to store individual match results
- Each match tracks: expected tool call, actual tool call, match type (TP/FP/FN/TN), and parameter correctness
- API and CLI updated to work with list of expected tool calls
- Added integration tests for multi-tool scenarios
- Updated documentation (specs, data model, OpenAPI) to reflect new capabilities

Breaking changes:
- TestCase model fields changed from expected_mcp_server_url/expected_tool_name/expected_parameters to expected_tool_calls array
- TestRun model changed from selected_tool/expected_tool/parameter_correctness to tool_call_matches array and avg_parameter_correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)